### PR TITLE
Fix: Add space before sequence in chain concatenation to fix for unpa…

### DIFF
--- a/scripts/PDBFUNCS.pm
+++ b/scripts/PDBFUNCS.pm
@@ -3692,7 +3692,7 @@ sub pdb_seqres {
 		$sqlen[$nch]        = $sqlen;
 	    }
 	    elsif ($cur_chain =~ /^$prv_chain$/) {
-		$chsq_ref->[$nch] .= $sq;
+		$chsq_ref->[$nch] .= " " . $sq;
 	    }
 	    else { 
 		$nch ++; 


### PR DESCRIPTION
…dded SEQRES

Append a space before concatenating the sequence to the chain.